### PR TITLE
CLUSTER before CREATE INDEX improves import time

### DIFF
--- a/import_/import.go
+++ b/import_/import.go
@@ -241,6 +241,17 @@ func Import(importOpts config.Import) {
 			log.Fatal("database not generalizeable")
 		}
 
+		if importOpts.Optimize {
+			if db, ok := db.(database.Optimizer); ok {
+				if err := db.Optimize(); err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				log.Fatal("database not optimizable")
+			}
+			importOpts.Optimize = false
+		}
+
 		if db, ok := db.(database.Finisher); ok {
 			if err := db.Finish(); err != nil {
 				log.Fatal(err)


### PR DESCRIPTION
When write+optimize are done during import, it is better to CLUSTER the tables before CREATE INDEX.
This avoid:
- double index creation
- additional storage the index during CLUSTER

A quick test shows a clustering time divided by 2 on my setup on Paris region extract, and indexing time is identical.
Total extract import is done in 2'40" instead of 3'45".